### PR TITLE
Chrome 92 でダイアログが使えない問題の延命

### DIFF
--- a/compatible.html
+++ b/compatible.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html lang="en" style="margin: 0;">
   <head>
+    <meta
+      http-equiv="origin-trial"
+      content="Ah+J7iGEj1axTTP82msRWpCKFIc871JVAkv0PbZKvhYER1xYLRKS5ydI8o1zHxz8pVLnzUCjj5rnUzD9/EY+DAcAAACLeyJvcmlnaW4iOiJodHRwczovL2hhY2tmb3JwbGF5Lnh5ejo0NDMiLCJmZWF0dXJlIjoiRGlzYWJsZURpZmZlcmVudE9yaWdpblN1YmZyYW1lRGlhbG9nU3VwcHJlc3Npb24iLCJleHBpcnkiOjE2Mzk1MjYzOTksImlzU3ViZG9tYWluIjp0cnVlfQ=="
+    />
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script
       async

--- a/compatible.html
+++ b/compatible.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" style="margin: 0;">
+<html lang="en" style="margin: 0">
   <head>
     <meta
       http-equiv="origin-trial"
@@ -58,7 +58,7 @@
       }
     </style>
   </head>
-  <body style="margin: 0;">
+  <body style="margin: 0">
     <div id="app"></div>
     <script src="./src/index.ts" async defer></script>
     <script src="./src/requestFullScreenPolyfill.js" async defer></script>


### PR DESCRIPTION
Origin Trial に登録する
https://developer.chrome.com/origintrials/#/registration/-832180768645054463

オリジンは `https://hackforplay.xyz` かつ全てのサブドメインで登録

localhost で実験するには別の token が必要になって面倒なので、このまま出してしまう