### PR TITLE
package.jsonにbrowserlistの設定を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sandbox",
   "version": "1.0.0",
   "description": "",
+  "browserslist": "> 0.5%, last 2 versions, not dead",
   "scripts": {
     "clean": "rm -rf ./dist",
     "lint": "npx prettier -l 'src/**/*.(ts|tsx)'",

--- a/src/styles/utils.scss
+++ b/src/styles/utils.scss
@@ -1,12 +1,6 @@
 @mixin select($value: none) {
   -webkit-touch-callout: $value; /* iOS Safari */
-  -webkit-user-select: $value; /* Safari */
-  -khtml-user-select: $value; /* Konqueror HTML */
-  -moz-user-select: $value; /* Old versions of Firefox */
-  -ms-user-select: $value; /* Internet Explorer/Edge */
-  user-select: $value; /* Non-prefixed version, currently
-                          supported by Chrome, Opera and Firefox */
-
+  user-select: $value;
   touch-action: none;
 }
 


### PR DESCRIPTION
why

[https://scrapbox.io/hackforplay-inc/スマホでゲーム画面を長押しするとHTML要素が文字選択されてしまう](https://scrapbox.io/hackforplay-inc/%E3%82%B9%E3%83%9E%E3%83%9B%E3%81%A7%E3%82%B2%E3%83%BC%E3%83%A0%E7%94%BB%E9%9D%A2%E3%82%92%E9%95%B7%E6%8A%BC%E3%81%97%E3%81%99%E3%82%8B%E3%81%A8HTML%E8%A6%81%E7%B4%A0%E3%81%8C%E6%96%87%E5%AD%97%E9%81%B8%E6%8A%9E%E3%81%95%E3%82%8C%E3%81%A6%E3%81%97%E3%81%BE%E3%81%86)というバグの修正

#51 の続き

`-webkit-user-select: none;` が消えていたのが２つ目の原因だった
なぜ消えていたかというと、package.jsonにbrowserlistの設定を書いていなかったため、Autoprefixで逆に消されていた

browserlistを設定したことで、CSSのvendor prefixは自分で書かなくても良くなった
